### PR TITLE
Differentiation between Pyrite 1 and 2 + Block SID Auth schema check

### DIFF
--- a/common.c
+++ b/common.c
@@ -111,9 +111,13 @@ static int tcg_discovery_0_process_feature(struct disk_device *dev, void *data, 
         dev->features.opal2 = *body;
         dev->base_com_id = be16_to_cpu(body->base_comID);
     // } else if (feature_code == 0x0301) { /* Opalite SSC */
-    } else if (feature_code == 0x0302 || feature_code == 0x0303) {
+    } else if (feature_code == 0x0302) {
         struct level_0_discovery_pyrite_feature *body = data;
-        dev->features.pyrite = *body;
+        dev->features.pyrite1 = *body;
+        dev->base_com_id = be16_to_cpu(body->base_comID);
+    } else if (feature_code == 0x0303) {
+        struct level_0_discovery_pyrite_feature *body = data;
+        dev->features.pyrite2 = *body;
         dev->base_com_id = be16_to_cpu(body->base_comID);
     // } else if (feature_code == 0x0304) { /* Ruby SSC */
     // } else if (feature_code == 0x0305) { /* Key per IO SSC */

--- a/common.h
+++ b/common.h
@@ -441,7 +441,8 @@ struct disk_device {
         struct level_0_discovery_single_user_mode_feature single_user_mode;
         struct level_0_discovery_data_store_feature data_store;
         struct level_0_discovery_block_sid_authentication_feature block_sid_authentication;
-        struct level_0_discovery_pyrite_feature pyrite;
+        struct level_0_discovery_pyrite_feature pyrite2;
+        struct level_0_discovery_pyrite_feature pyrite1;
         struct level_0_discovery_supported_data_removal_mechanism_feature supported_data_removal_mechanism;
         struct level_0_discovery_ns_locking_feature ns_locking;
         struct level_0_discovery_ns_geometry_feature ns_geometry;

--- a/discovery.c
+++ b/discovery.c
@@ -184,7 +184,19 @@ static void print_level_0_discovery(struct disk_device *dev)
         struct level_0_discovery_block_sid_authentication_feature *body = &dev->features.block_sid_authentication;
 
         print_comma_start(&first);
-        printf("  \"Block SID Authentication Feature\": {\n"
+        if(body->shared.descriptor_version == 0x1){
+            printf("  \"Block SID Authentication Feature\": {\n"
+               "    \"Version\": %i,\n"
+               "    \"SID Authentication Blocked State\": %i,\n"
+               "    \"SID Value State\": %i,\n"
+               "    \"Hardware Reset\": %i\n"
+               "  }",
+               body->shared.descriptor_version, body->sid_authentication_blocked_state, body->sid_value_state,
+               body->hardware_reset);
+        }
+        // else if instead of else in case TCG decide to add more params
+        else if(body->shared.descriptor_version == 0x2){
+            printf("  \"Block SID Authentication Feature\": {\n"
                "    \"Version\": %i,\n"
                "    \"Locking SP Freeze Lock State \": %i,\n"
                "    \"Locking SP Freeze Lock supported\": %i,\n"
@@ -195,13 +207,29 @@ static void print_level_0_discovery(struct disk_device *dev)
                body->shared.descriptor_version, body->locking_sp_freeze_lock_state,
                body->locking_sp_freeze_lock_supported, body->sid_authentication_blocked_state, body->sid_value_state,
                body->hardware_reset);
+        }
     }
 
-    if (dev->features.pyrite.shared.feature_code) {
-        struct level_0_discovery_pyrite_feature *body = &dev->features.pyrite;
+    if (dev->features.pyrite1.shared.feature_code) {
+        struct level_0_discovery_pyrite_feature *body = &dev->features.pyrite1;
 
         print_comma_start(&first);
         printf("  \"Pyrite SSC Feature Descriptor\": {\n"
+               "    \"Version\": %i,\n"
+               "    \"Base ComID\": %i,\n"
+               "    \"Number of ComIDs\": %i,\n"
+               "    \"Initial C_PIN_SID PIN Indicator\": %i,\n"
+               "    \"Behavior of C_PIN_SID PIN upon TPer Revert\": %i\n"
+               "  }",
+               body->shared.descriptor_version, be16_to_cpu(body->base_comID),
+               be16_to_cpu(body->number_of_comIDs), body->initial_pin_indicator, body->behavior_of_pin_upon_revert);
+    }
+
+    if (dev->features.pyrite2.shared.feature_code) {
+        struct level_0_discovery_pyrite_feature *body = &dev->features.pyrite2;
+
+        print_comma_start(&first);
+        printf("  \"Pyrite SSC V2 Feature Descriptor\": {\n"
                "    \"Version\": %i,\n"
                "    \"Base ComID\": %i,\n"
                "    \"Number of ComIDs\": %i,\n"

--- a/discovery.c
+++ b/discovery.c
@@ -184,7 +184,7 @@ static void print_level_0_discovery(struct disk_device *dev)
         struct level_0_discovery_block_sid_authentication_feature *body = &dev->features.block_sid_authentication;
 
         print_comma_start(&first);
-        if(body->shared.descriptor_version == 0x1){
+        if (body->shared.descriptor_version == 0x1){
             printf("  \"Block SID Authentication Feature\": {\n"
                "    \"Version\": %i,\n"
                "    \"SID Authentication Blocked State\": %i,\n"
@@ -195,7 +195,7 @@ static void print_level_0_discovery(struct disk_device *dev)
                body->hardware_reset);
         }
         // else if instead of else in case TCG decide to add more params
-        else if(body->shared.descriptor_version == 0x2){
+        else if (body->shared.descriptor_version == 0x2){
             printf("  \"Block SID Authentication Feature\": {\n"
                "    \"Version\": %i,\n"
                "    \"Locking SP Freeze Lock State \": %i,\n"


### PR DESCRIPTION
The tool now differentiates between Pyrite 1 and 2. Also an additional check was added to print of Block SID Auth. because version 2 has new parameters.